### PR TITLE
Prevent duplication session during auto start

### DIFF
--- a/screen-auto-start
+++ b/screen-auto-start
@@ -32,5 +32,7 @@ for file in "${SAVE_DIR}"*
 do
 	/usr/bin/env screen -D -m -c "$file" &
 	screen_pid=$!
-	mv "$file" "$DEFAULT_SAVE_DIR$screen_pid"
+	if [[ $file =~ "-pid-" ]]; then
+		mv "$file" "$DEFAULT_SAVE_DIR-pid-$screen_pid"
+	fi
 done

--- a/screen-auto-start
+++ b/screen-auto-start
@@ -30,5 +30,7 @@ fi
 
 for file in "${SAVE_DIR}"*
 do
-	/usr/bin/env screen -d -m -c "$file"
+	/usr/bin/env screen -D -m -c "$file" &
+	screen_pid=$!
+	mv "$file" "$DEFAULT_SAVE_DIR$screen_pid"
 done

--- a/screen-auto-start
+++ b/screen-auto-start
@@ -32,7 +32,8 @@ for file in "${SAVE_DIR}"*
 do
 	/usr/bin/env screen -D -m -c "$file" &
 	screen_pid=$!
+	sleep 1
 	if [[ $file =~ "-pid-" ]]; then
-		mv "$file" "$DEFAULT_SAVE_DIR-pid-$screen_pid"
+		mv "$file" "${DEFAULT_SAVE_DIR}pid-${screen_pid}"
 	fi
 done


### PR DESCRIPTION
Should be close #19 

A way to prevent duplicate saved session, we can just rename anonymous saved file with new pid